### PR TITLE
Switch go version from 1.13 to 1.17 to support darwin/arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.17.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
Signed-off-by: Jan Dubois <jan.dubois@suse.com>